### PR TITLE
added error number and qualified existing ones

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "aggregateless-eventstore",
-  "version": "0.1.0",
+  "name": "typescript-eventstore",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "aggregateless-eventstore",
-      "version": "0.1.0",
+      "name": "typescript-eventstore",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "dotenv": "^17.0.1",

--- a/src/eventstore/notifiers/memory/__tests__/index.test.ts
+++ b/src/eventstore/notifiers/memory/__tests__/index.test.ts
@@ -197,7 +197,7 @@ describe('MemoryEventStreamNotifier', () => {
       await notifier.notify(events);
       
       expect(consoleSpy).toHaveBeenCalledWith(
-        `Error notifying subscription ${subscription.id}:`,
+        `notifiers-memory-err01: Error notifying subscription ${subscription.id}:`,
         expect.any(Error)
       );
       

--- a/src/eventstore/notifiers/memory/index.ts
+++ b/src/eventstore/notifiers/memory/index.ts
@@ -30,7 +30,7 @@ export class MemoryEventStreamNotifier implements EventStreamNotifier {
       try {
         await subscription.handle(events);
       } catch (error) {
-        console.error(`Error notifying subscription ${subscription.id}:`, error);
+        console.error(`notifiers-memory-err01: Error notifying subscription ${subscription.id}:`, error);
       }
     });
 

--- a/src/eventstore/stores/postgres/schema.ts
+++ b/src/eventstore/stores/postgres/schema.ts
@@ -35,7 +35,7 @@ export function getDatabaseNameFromConnectionString(connStr: string): string | n
     const dbName = url.pathname.startsWith('/') ? url.pathname.slice(1) : url.pathname;
     return dbName || null;
   } catch (err) {
-    console.error('err01: Invalid connection string:', err);
+    console.error('eventstore-stores-postgres-err01: Invalid connection string:', err);
     return null;
   }
 }

--- a/src/eventstore/stores/postgres/store.ts
+++ b/src/eventstore/stores/postgres/store.ts
@@ -35,10 +35,10 @@ export class PostgresEventStore implements EventStore {
 
   constructor(options: PostgresEventStoreOptions = {}) {
     const connectionString = options.connectionString || process.env.DATABASE_URL;
-    if (!connectionString) throw new Error('err02: Connection string missing. DATABASE_URL environment variable not set.');
+    if (!connectionString) throw new Error('eventstore-stores-postgres-err02: Connection string missing. DATABASE_URL environment variable not set.');
 
     const databaseNameFromConnectionString = getDatabaseNameFromConnectionString(connectionString);
-    if (!databaseNameFromConnectionString) throw new Error('err03: Database name not found. Invalid connection string: ' + connectionString);
+    if (!databaseNameFromConnectionString) throw new Error('eventstore-stores-postgres-err03: Database name not found. Invalid connection string: ' + connectionString);
     this.databaseName = databaseNameFromConnectionString;
 
     this.pool = new Pool({ connectionString });
@@ -75,7 +75,7 @@ export class PostgresEventStore implements EventStore {
     }
 
     if (expectedMaxSequenceNumber === undefined)
-      throw new Error('err04: Expected max sequence number is required when a filter is provided!')
+      throw new Error('eventstore-stores-postgres-err04: Expected max sequence number is required when a filter is provided!')
 
     const client = await this.pool.connect();
     try {
@@ -85,7 +85,7 @@ export class PostgresEventStore implements EventStore {
       const result = await client.query(cteQuery.sql, params);
 
       if (result.rowCount === 0) {
-        throw new Error('err05: Context changed: events were modified between query() and append()');
+        throw new Error('eventstore-stores-postgres-err05: Context changed: events were modified between query() and append()');
       }
 
       // Convert inserted records to EventRecord[] and notify subscribers
@@ -121,7 +121,7 @@ export class PostgresEventStore implements EventStore {
       console.log(`Database created: ${this.databaseName}`);
     } catch (err: any) {
       if (err.code === '42P04') {
-        console.log(`err06: Database already exists: ${this.databaseName}`);
+        console.log(`eventstore-stores-postgres-err06: Database already exists: ${this.databaseName}`);
       } else {
         throw err;
       }

--- a/tests/optimistic-locking.test.ts
+++ b/tests/optimistic-locking.test.ts
@@ -71,7 +71,7 @@ describe('Optimistic Locking CTE Condition', () => {
     const event2 = new TestEvent(eventType, 'test-2.2', { value: 'second' });
     await expect(
       eventStore.append([event2], filter, 0) // Using outdated sequence 0 instead of current
-    ).rejects.toThrow('err05');
+    ).rejects.toThrow('eventstore-stores-postgres-err05');
     
     // Verify the second event was NOT inserted
     const afterFailedInsert = await eventStore.query(filter);
@@ -103,7 +103,7 @@ describe('Optimistic Locking CTE Condition', () => {
     const event2 = new TestEvent(eventType, 'concurrent-3.b.1', { process: 'B' });
     await expect(
       eventStore.append([event2], filter, result2.maxSequenceNumber)
-    ).rejects.toThrow('err05');
+    ).rejects.toThrow('eventstore-stores-postgres-err05');
     
     // Verify only the first event was inserted
     const finalResult = await eventStore.query(filter);
@@ -207,7 +207,7 @@ describe('Optimistic Locking CTE Condition', () => {
     };
     await expect(
       eventStore.append([event3], filter, currentSequence) // Outdated, should be currentSequence + 1
-    ).rejects.toThrow('err05');
+    ).rejects.toThrow('eventstore-stores-postgres-err05');
   });
 
 });


### PR DESCRIPTION
minor improvement: all error messages now have a prefix independent of the concrete message.
this makes testing easier.

the prefix is specific to the context (eg postgres event store vs in-mem notifier).