### PR TITLE
Some fixes made after suggestions from Codex

### DIFF
--- a/src/eventstore/stores/memory/__tests__/index.test.ts
+++ b/src/eventstore/stores/memory/__tests__/index.test.ts
@@ -3,6 +3,10 @@ import { EventRecord } from "../../../types";
 import { MemoryEventStore } from "../index";
 import * as fs from 'fs';
 
+function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 describe('MemoryEventStore', () => {
     let sut:MemoryEventStore;
 
@@ -104,21 +108,42 @@ describe('MemoryEventStore', () => {
 
 
     describe("EventStore Locking", () => {
-        it("should block query while append is running", async () => {
+        it("should not block query while notifications are running", async () => {
+            await sut.subscribe(async () => {
+                await sleep(50);
+            });
+
             const results: string[] = [];
 
-            // Start append operation
             const appendPromise = sut.append([{ eventType: 'test', payload: {} }])
                 .then(() => results.push('append-done'));
 
-            // Start query immediately after (should be blocked)
-            const queryPromise = sut.query()
+            await sleep(5);
+
+            await sut.query()
                 .then(() => results.push('query-done'));
 
-            await Promise.all([appendPromise, queryPromise]);
+            await appendPromise;
 
-            // Append should complete before query
-            expect(results).toEqual(['append-done', 'query-done']);
+            expect(results).toEqual(['query-done', 'append-done']);
+        });
+
+        it("should keep notification order across concurrent appends", async () => {
+            const notificationOrder: number[][] = [];
+
+            await sut.subscribe(async (events) => {
+                if (events[0]?.eventType === 'slow') {
+                    await sleep(40);
+                }
+                notificationOrder.push(events.map((event) => event.sequenceNumber));
+            });
+
+            const firstAppend = sut.append([{ eventType: 'slow', payload: {} }]);
+            const secondAppend = sut.append([{ eventType: 'fast', payload: {} }]);
+
+            await Promise.all([firstAppend, secondAppend]);
+
+            expect(notificationOrder).toEqual([[1], [2]]);
         });
     }); 
 

--- a/src/eventstore/stores/memory/index.ts
+++ b/src/eventstore/stores/memory/index.ts
@@ -1,4 +1,4 @@
-import { Event, EventStore, EventFilter, EventQuery, QueryResult, EventStreamNotifier, HandleEvents, EventSubscription } from '../../types';
+import { Event, EventStore, EventFilter, EventQuery, QueryResult, EventStreamNotifier, HandleEvents, EventSubscription, EventRecord } from '../../types';
 import { MemoryEventStreamNotifier } from '../../notifiers';
 import { createQuery } from '../../filter';
 
@@ -12,6 +12,7 @@ export class MemoryEventStore implements EventStore {
   private notifier: EventStreamNotifier = new MemoryEventStreamNotifier();
   private lock: ReadWriteLockFIFO = new ReadWriteLockFIFO();
   private writeThruFilename: string | undefined;
+  private notificationQueue: Promise<void> = Promise.resolve();
 
   constructor(writeThruFilename?: string) {
     this.writeThruFilename = writeThruFilename;
@@ -59,6 +60,7 @@ export class MemoryEventStore implements EventStore {
   async append(events: Event[], filterCriteria: EventQuery, expectedMaxSequenceNumber: number): Promise<void>;
   async append(events: Event[], filterCriteria: EventFilter, expectedMaxSequenceNumber: number): Promise<void>;
   async append(events: Event[], queryOrFilter?: EventQuery | EventFilter,  expectedMaxSequenceNumber?: number): Promise<void> {
+    let eventRecords: EventRecord[] = [];
     await this.lock.acquireWrite();
     try {
         if (expectedMaxSequenceNumber !== undefined) {
@@ -73,23 +75,28 @@ export class MemoryEventStore implements EventStore {
             }
         }
 
-        const eventRecords = this.eventStream.append(events);
+        eventRecords = this.eventStream.append(events);
 
         if (this.writeThruFilename) {
             await this.storeToFile(this.writeThruFilename);
         }
-
-        await this.notifier.notify(eventRecords);
-            // TODO: or should this be moved after the lock release? would probably require queueing notifications to keep them in order
     }
     finally {
         this.lock.releaseWrite();
     }
+
+    await this.enqueueNotification(eventRecords);
   }
 
 
   async subscribe(handle: HandleEvents): Promise<EventSubscription> {
     return await this.notifier.subscribe(handle);
+  }
+
+  private enqueueNotification(events: EventRecord[]): Promise<void> {
+    const next = this.notificationQueue.then(() => this.notifier.notify(events));
+    this.notificationQueue = next.catch(() => undefined);
+    return next;
   }
 
 

--- a/src/eventstore/stores/postgres/__tests__/schema.test.ts
+++ b/src/eventstore/stores/postgres/__tests__/schema.test.ts
@@ -12,7 +12,12 @@ describe('Schema Functions', () => {
   describe('createDatabaseQuery', () => {
     it('should create database query string', () => {
       const result = createDatabaseQuery('testdb');
-      expect(result).toBe('CREATE DATABASE testdb');
+      expect(result).toBe('CREATE DATABASE "testdb"');
+    });
+
+    it('should escape double quotes in database name', () => {
+      const result = createDatabaseQuery('te"stdb');
+      expect(result).toBe('CREATE DATABASE "te""stdb"');
     });
   });
 

--- a/src/eventstore/stores/postgres/__tests__/sql.test.ts
+++ b/src/eventstore/stores/postgres/__tests__/sql.test.ts
@@ -27,27 +27,27 @@ describe('Sql builder', () => {
       const result = buildAppendSql(createQuery(createFilter([],[])), 1);
       expect(result.sql).toBe(`WITH context AS (SELECT MAX(sequence_number) AS max_seq FROM events)
 INSERT INTO events (event_type, payload)
-SELECT unnest($1::text[]), unnest($2::jsonb[]) FROM context WHERE COALESCE(max_seq, 0) = 1
+SELECT unnest($2::text[]), unnest($3::jsonb[]) FROM context WHERE COALESCE(max_seq, 0) = $1
 RETURNING *`);
-      expect(result.params).toEqual([]);
+      expect(result.params).toEqual([1]);
     });
 
     it('event type', () => {
       const result = buildAppendSql(createQuery(createFilter(["t1"],[])), 2);
       expect(result.sql).toBe(`WITH context AS (SELECT MAX(sequence_number) AS max_seq FROM events WHERE ((event_type = ANY($1))))
 INSERT INTO events (event_type, payload)
-SELECT unnest($2::text[]), unnest($3::jsonb[]) FROM context WHERE COALESCE(max_seq, 0) = 2
+SELECT unnest($3::text[]), unnest($4::jsonb[]) FROM context WHERE COALESCE(max_seq, 0) = $2
 RETURNING *`);
-      expect(result.params).toEqual([["t1"]]);
+      expect(result.params).toEqual([["t1"], 2]);
     });
 
     it('event type with payload', () => {
       const result = buildAppendSql(createQuery(createFilter(["t1"],[{a:1}])), 3);
       expect(result.sql).toBe(`WITH context AS (SELECT MAX(sequence_number) AS max_seq FROM events WHERE ((event_type = ANY($1) AND (payload @> $2))))
 INSERT INTO events (event_type, payload)
-SELECT unnest($3::text[]), unnest($4::jsonb[]) FROM context WHERE COALESCE(max_seq, 0) = 3
+SELECT unnest($4::text[]), unnest($5::jsonb[]) FROM context WHERE COALESCE(max_seq, 0) = $3
 RETURNING *`);
-      expect(result.params).toEqual([["t1"], "{\"a\":1}"]);
+      expect(result.params).toEqual([["t1"], "{\"a\":1}", 3]);
     });
   });
 });

--- a/src/eventstore/stores/postgres/__tests__/transform.test.ts
+++ b/src/eventstore/stores/postgres/__tests__/transform.test.ts
@@ -21,12 +21,11 @@ describe('Transform Functions', () => {
 
       const result = deserializeEvent(row);
 
-      expect(result).toEqual({
-        payload: { data: 'test', userId: '456' },
-        eventType: 'UserCreated',
-        sequenceNumber: '123',
-        timestamp: '2023-01-01T00:00:00Z'
-      });
+      expect(result.payload).toEqual({ data: 'test', userId: '456' });
+      expect(result.eventType).toBe('UserCreated');
+      expect(result.sequenceNumber).toBe(123);
+      expect(result.timestamp).toBeInstanceOf(Date);
+      expect(result.timestamp.toISOString()).toBe('2023-01-01T00:00:00.000Z');
     });
 
     it('should handle already parsed JSON payload', () => {
@@ -39,12 +38,33 @@ describe('Transform Functions', () => {
 
       const result = deserializeEvent(row);
 
-      expect(result).toEqual({
-        payload: { data: 'test', userId: '456' },
-        eventType: 'UserCreated',
-        sequenceNumber: '123',
-        timestamp: '2023-01-01T00:00:00Z'
-      });
+      expect(result.payload).toEqual({ data: 'test', userId: '456' });
+      expect(result.eventType).toBe('UserCreated');
+      expect(result.sequenceNumber).toBe(123);
+      expect(result.timestamp).toBeInstanceOf(Date);
+      expect(result.timestamp.toISOString()).toBe('2023-01-01T00:00:00.000Z');
+    });
+
+    it('should throw when sequence number is not a safe integer', () => {
+      const row = {
+        event_type: 'UserCreated',
+        sequence_number: '9007199254740992',
+        occurred_at: '2023-01-01T00:00:00Z',
+        payload: { data: 'test', userId: '456' }
+      };
+
+      expect(() => deserializeEvent(row)).toThrow('eventstore-stores-postgres-err09');
+    });
+
+    it('should throw when timestamp is invalid', () => {
+      const row = {
+        event_type: 'UserCreated',
+        sequence_number: '123',
+        occurred_at: 'not-a-date',
+        payload: { data: 'test', userId: '456' }
+      };
+
+      expect(() => deserializeEvent(row)).toThrow('eventstore-stores-postgres-err10');
     });
   });
 

--- a/src/eventstore/stores/postgres/schema.ts
+++ b/src/eventstore/stores/postgres/schema.ts
@@ -19,8 +19,18 @@ export const CREATE_PAYLOAD_GIN_INDEX = `
   CREATE INDEX IF NOT EXISTS idx_events_payload_gin ON events USING gin(payload)
 `;
 
+function quoteIdentifier(identifier: string): string {
+  if (identifier.length === 0) {
+    throw new Error('eventstore-stores-postgres-err07: Database name must not be empty');
+  }
+  if (identifier.includes('\u0000')) {
+    throw new Error('eventstore-stores-postgres-err08: Database name must not contain null bytes');
+  }
+  return `"${identifier.replace(/"/g, '""')}"`;
+}
+
 export function createDatabaseQuery(dbName: string): string {
-  return `CREATE DATABASE ${dbName}`;
+  return `CREATE DATABASE ${quoteIdentifier(dbName)}`;
 }
 
 export function changeDatabaseInConnectionString(connStr: string, newDbName: string): string {

--- a/src/eventstore/stores/postgres/sql.ts
+++ b/src/eventstore/stores/postgres/sql.ts
@@ -67,15 +67,16 @@ export function buildAppendSql(query: EventQuery, expectedMaxSeq: number): { sql
   const conditions = compileContextQueryConditions(query);
   
   const contextParamCount = conditions.params.length;
-  const eventTypesParam = contextParamCount + 1;
-  const payloadsParam = contextParamCount + 2;
+  const expectedMaxSeqParam = contextParamCount + 1;
+  const eventTypesParam = contextParamCount + 2;
+  const payloadsParam = contextParamCount + 3;
 
   return {
     sql: 
 `WITH context AS (SELECT MAX(sequence_number) AS max_seq FROM events${conditions.sql.length > 0 ? " WHERE " + conditions.sql : ""})
 INSERT INTO events (event_type, payload)
-SELECT unnest($${eventTypesParam}::text[]), unnest($${payloadsParam}::jsonb[]) FROM context WHERE COALESCE(max_seq, 0) = ${expectedMaxSeq}
+SELECT unnest($${eventTypesParam}::text[]), unnest($${payloadsParam}::jsonb[]) FROM context WHERE COALESCE(max_seq, 0) = $${expectedMaxSeqParam}
 RETURNING *`,
-    params: conditions.params
+    params: [...conditions.params, expectedMaxSeq]
   };
 }

--- a/src/eventstore/stores/postgres/store.ts
+++ b/src/eventstore/stores/postgres/store.ts
@@ -39,12 +39,14 @@ export interface PostgresEventStoreOptions {
  */
 export class PostgresEventStore implements EventStore {
   private pool: Pool;
+  private readonly connectionString: string;
   private readonly databaseName: string;
   private readonly notifier: EventStreamNotifier;
 
   constructor(options: PostgresEventStoreOptions = {}) {
     const connectionString = options.connectionString || process.env.DATABASE_URL;
     if (!connectionString) throw new Error('eventstore-stores-postgres-err02: Connection string missing. DATABASE_URL environment variable not set.');
+    this.connectionString = connectionString;
 
     const databaseNameFromConnectionString = getDatabaseNameFromConnectionString(connectionString);
     if (!databaseNameFromConnectionString) throw new Error('eventstore-stores-postgres-err03: Database name not found. Invalid connection string: ' + connectionString);
@@ -140,7 +142,7 @@ export class PostgresEventStore implements EventStore {
 
   private async createDatabase(): Promise<void> {
     const adminConnectionString = changeDatabaseInConnectionString(
-      process.env.DATABASE_URL!,
+      this.connectionString,
       'postgres'
     );
 

--- a/src/eventstore/stores/postgres/transform.ts
+++ b/src/eventstore/stores/postgres/transform.ts
@@ -1,11 +1,27 @@
 import { QueryResult } from 'pg';
 import { EventRecord, Event } from '../../types';
 
+function toSequenceNumber(value: unknown): number {
+  const parsed = typeof value === 'number' ? value : Number(value);
+  if (!Number.isInteger(parsed) || !Number.isSafeInteger(parsed)) {
+    throw new Error('eventstore-stores-postgres-err09: sequence_number is not a safe integer');
+  }
+  return parsed;
+}
+
+function toTimestamp(value: unknown): Date {
+  const parsed = value instanceof Date ? value : new Date(String(value));
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error('eventstore-stores-postgres-err10: occurred_at is not a valid timestamp');
+  }
+  return parsed;
+}
+
 
 export function deserializeEvent(row: any): EventRecord {
   return {
-    sequenceNumber: row.sequence_number,
-    timestamp: row.occurred_at,
+    sequenceNumber: toSequenceNumber(row.sequence_number),
+    timestamp: toTimestamp(row.occurred_at),
     eventType: row.event_type,
     payload: typeof row.payload === 'string' ? JSON.parse(row.payload) : row.payload,
   };

--- a/test.json
+++ b/test.json
@@ -1,1 +1,1 @@
-{"eventRecords":[{"sequenceNumber":1,"timestamp":"2026-02-22T18:15:33.706Z","eventType":"e1","payload":{"m":"hello"}},{"sequenceNumber":2,"timestamp":"2026-02-22T18:15:33.706Z","eventType":"e2","payload":{"m":"world"}}],"lastSequenceNumber":2}
+{"eventRecords":[{"sequenceNumber":1,"timestamp":"2026-03-11T06:42:22.375Z","eventType":"e1","payload":{"m":"hello"}},{"sequenceNumber":2,"timestamp":"2026-03-11T06:42:22.375Z","eventType":"e2","payload":{"m":"world"}}],"lastSequenceNumber":2}

--- a/test.json
+++ b/test.json
@@ -1,1 +1,1 @@
-{"eventRecords":[{"sequenceNumber":1,"timestamp":"2026-03-11T06:42:22.375Z","eventType":"e1","payload":{"m":"hello"}},{"sequenceNumber":2,"timestamp":"2026-03-11T06:42:22.375Z","eventType":"e2","payload":{"m":"world"}}],"lastSequenceNumber":2}
+{"eventRecords":[{"sequenceNumber":1,"timestamp":"2026-03-11T06:56:59.333Z","eventType":"e1","payload":{"m":"hello"}},{"sequenceNumber":2,"timestamp":"2026-03-11T06:56:59.333Z","eventType":"e2","payload":{"m":"world"}}],"lastSequenceNumber":2}

--- a/write-thru.json
+++ b/write-thru.json
@@ -1,1 +1,1 @@
-{"eventRecords":[{"sequenceNumber":1,"timestamp":"2026-03-11T06:42:22.390Z","eventType":"e1","payload":{"m":"hello"}}],"lastSequenceNumber":1}
+{"eventRecords":[{"sequenceNumber":1,"timestamp":"2026-03-11T06:56:59.343Z","eventType":"e1","payload":{"m":"hello"}}],"lastSequenceNumber":1}

--- a/write-thru.json
+++ b/write-thru.json
@@ -1,1 +1,1 @@
-{"eventRecords":[{"sequenceNumber":1,"timestamp":"2026-02-22T18:15:33.714Z","eventType":"e1","payload":{"m":"hello"}}],"lastSequenceNumber":1}
+{"eventRecords":[{"sequenceNumber":1,"timestamp":"2026-03-11T06:42:22.390Z","eventType":"e1","payload":{"m":"hello"}}],"lastSequenceNumber":1}


### PR DESCRIPTION
[P1] Falsche DB-Quelle bei initializeDatabase()
In der Postgres-Implementierung wird beim DB-Anlegen nicht die konfigurierte connectionString aus dem Konstruktor verwendet, sondern hart process.env.DATABASE_URL!. Wenn du new PostgresEventStore({ connectionString: ... }) nutzt, kann die Initialisierung gegen eine andere Instanz laufen oder crashen, falls DATABASE_URL fehlt.
Referenz: [store.ts](/Users/ralfw/Repositories/02 projekte/rico eventstore-typescript/src/eventstore/stores/postgres/store.ts:141), [store.ts](/Users/ralfw/Repositories/02 projekte/rico eventstore-typescript/src/eventstore/stores/postgres/store.ts:143)

[P1] CREATE DATABASE ist unescaped zusammengesetzt
createDatabaseQuery interpoliert den DB-Namen direkt in SQL (CREATE DATABASE ${dbName}) ohne Identifier-Quoting/Validierung. Das ist riskant (Injection/ungültige Namen) und bricht bei Sonderzeichen.
Referenz: [schema.ts](/Users/ralfw/Repositories/02 projekte/rico eventstore-typescript/src/eventstore/stores/postgres/schema.ts:22)

[P2] Typvertrag EventRecord wird in Postgres-Transform verletzt
Laut Typen ist sequenceNumber: number und timestamp: Date, aber deserializeEvent gibt raw DB-Werte zurück (oft string bei BIGINT/TIMESTAMPTZ). Die Tests bestätigen diese String-Form sogar. Das erzeugt inkonsistentes Verhalten zwischen Memory- und Postgres-Store.
Referenz: [types.ts](/Users/ralfw/Repositories/02 projekte/rico eventstore-typescript/src/eventstore/types.ts:14), [transform.ts](/Users/ralfw/Repositories/02 projekte/rico eventstore-typescript/src/eventstore/stores/postgres/transform.ts:5), [transform.test.ts](/Users/ralfw/Repositories/02 projekte/rico eventstore-typescript/src/eventstore/stores/postgres/tests/transform.test.ts:27)

[P2] Memory-Store hält Write-Lock während Subscriber-Notification
In append() bleibt der Write-Lock bis nach await notifier.notify(...) aktiv. Langsame/fehlerhafte Subscriber blockieren damit Queries/Appends unnötig lange (Head-of-line blocking). Der TODO im Code deutet das selbst an.
Referenz: [index.ts](/Users/ralfw/Repositories/02 projekte/rico eventstore-typescript/src/eventstore/stores/memory/index.ts:62), [index.ts](/Users/ralfw/Repositories/02 projekte/rico eventstore-typescript/src/eventstore/stores/memory/index.ts:82)

[P3] expectedMaxSeq wird direkt in SQL-String eingebettet
In buildAppendSql ist expectedMaxSeq nicht parametriert. Praktisch meist unkritisch (typed number), aber unnötig unsauber gegenüber dem restlichen parametrierten Stil.
Referenz: [sql.ts](/Users/ralfw/Repositories/02 projekte/rico eventstore-typescript/src/eventstore/stores/postgres/sql.ts:77)